### PR TITLE
Fixed 'Not a directory' on every check

### DIFF
--- a/git-repo-watcher
+++ b/git-repo-watcher
@@ -112,7 +112,9 @@ pull_change() {
 
 while [[ true ]]; do
 
-    cd "$git_repository_dir"
+    if [[ "$(basename $PWD)" != "$git_repository_dir" ]]; then
+	cd "$git_repository_dir"
+    fi
 
     if [[ -f ".git/index.lock" ]]; then
         echo "ERROR: Git repository is locked, waiting to unlock" >&2


### PR DESCRIPTION
After one check it threw './git-repo-watcher: line 115: cd: repo: Not a directory' as we are already in the directory. Added if statement on when we cd into the repo to only do it once.