### PR TITLE
Enable overwriting the pull behavior

### DIFF
--- a/git-repo-watcher
+++ b/git-repo-watcher
@@ -21,6 +21,35 @@ print_usage() {
     exit 1
 }
 
+# Executes user hooks
+#
+# $1    - Hook name
+# $2-$4 - Hook arguments
+hook() {
+    hook_name="$1"
+    shift
+    if [[ "$(type -t "$hook_name")" == "function" ]]; then
+        eval "$hook_name $*"
+    fi
+}
+
+# Pulls commit from remote git repository
+#
+# $1 - Git repository name
+# $2 - Branch name
+pull_change() {
+    git pull
+    exit_code=$?
+
+    commit_message=$(git log -1 --pretty=format:"%h | %an | %ad | %s")
+
+    if [[ $exit_code -eq 1 ]]; then
+        hook "pull_failed" "$1" "$2" "$commit_message"
+    else
+        hook "change_pulled" "$1" "$2" "$(printf '%q\n' "$commit_message")"
+    fi
+}
+
 while getopts ":d:i:h:o" options; do
     case "${options}" in
     d)
@@ -78,35 +107,6 @@ fi
 if [[ -z "$interval_in_seconds" ]]; then
     interval_in_seconds="$default_interval_in_seconds"
 fi
-
-# Executes user hooks
-#
-# $1    - Hook name
-# $2-$4 - Hook arguments
-hook() {
-    hook_name="$1"
-    shift
-    if [[ "$(type -t "$hook_name")" == "function" ]]; then
-        eval "$hook_name $*"
-    fi
-}
-
-# Pulls commit from remote git repository
-#
-# $1 - Git repository name
-# $2 - Branch name
-pull_change() {
-    git pull
-    exit_code=$?
-
-    commit_message=$(git log -1 --pretty=format:"%h | %an | %ad | %s")
-
-    if [[ $exit_code -eq 1 ]]; then
-        hook "pull_failed" "$1" "$2" "$commit_message"
-    else
-        hook "change_pulled" "$1" "$2" "$(printf '%q\n' "$commit_message")"
-    fi
-}
 
 while true; do
 


### PR DESCRIPTION
There is one hook dispatched by the system that can't be overridden because the override file is sourced before the hook gets defined. Thus the new definition overwrites the previous one.

This changes that behavior. This is useful for me when I like force pushing to amend commits.